### PR TITLE
Clarify secret_key usages

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -17,7 +17,6 @@ from common.utils import get_env_variable, set_env_from_secrets
 # Build paths inside the project like this: BASE_DIR.child('dirname')
 BASE_DIR = Path(__file__).ancestor(3)
 
-SECRET_KEY = 'aiz&fx%x9)bi_g$hl*c!*asiall(w@-34tm%&=urx=_%k447l_'
 DEBUG = True
 ALLOWED_HOSTS = []
 

--- a/config/settings/dev.py
+++ b/config/settings/dev.py
@@ -1,6 +1,7 @@
 # flake8: noqa
 from config.settings.base import *
 
+SECRET_KEY = 'not so secret, only used for docker commands locally'
 DEBUG = True
 ALLOWED_HOSTS = ['*']
 

--- a/config/settings/test.py
+++ b/config/settings/test.py
@@ -5,6 +5,7 @@ from config.settings.base import *
 
 logging.disable(logging.CRITICAL)
 
+SECRET_KEY = 'not so secret, only used for tests'
 DEBUG = True
 ALLOWED_HOSTS = ['*']
 

--- a/heroku.yml
+++ b/heroku.yml
@@ -7,7 +7,7 @@ setup:
 build:
   config:
     DJANGO_SETTINGS_MODULE: 'config.settings.prod'
-    SECRET_KEY: '&)rukj0c(mss(x'
+    SECRET_KEY: 'not so secret, only used for builds!'
   docker:
     web: Dockerfile.web
 release:


### PR DESCRIPTION
SECRET_KEY was set to an arbitrary value in certain places in the code but that was only used for build processes. Django would throw an error if it wasn't there during manage.py commands, etc.
Now, it's set to an even more clearly throwaway value. The prod.py SECRET_KEY was always set to pull from ENV variables